### PR TITLE
Add HeyClioo/boss-zhipin-jd-scraper (BOSS直聘 JD 抓取) to Chinese Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ GitHub 上 Star 数最高、最具话题度的单一用途 Skill。它们大多�
 | [**iamzifei/wechat-article-publisher-skill**](https://github.com/iamzifei/wechat-article-publisher-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/iamzifei/wechat-article-publisher-skill) | 一键发布文章到微信公众号的 Claude Skill。 |
 | [**GanymedeNil/poxiaoxing-skills**](https://github.com/GanymedeNil/poxiaoxing-skills) (破晓星) | ![GitHub Repo stars](https://badgen.net/github/stars/GanymedeNil/poxiaoxing-skills) | 知名开发者 [@GanymedeNil](https://github.com/GanymedeNil) 出品的破晓星 Skills 仓库，内含「抖音博主分析」技能：采集博主作品、下载视频、抽取截图，并可选用 DashScope FunASR 转写字幕，输出结构化素材供后续分析。 |
 | [**dososo/blcaptain-ppt-skill**](https://github.com/dososo/blcaptain-ppt-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/dososo/blcaptain-ppt-skill) | AI 原生·单文件 HTML 演示 Skill：7 套锚定公认设计体系的视觉人格，好看（WCAG/间距/32 维审计）与诚实（反伪造）均由机器强制，零依赖。 |
+| [**HeyClioo/boss-zhipin-jd-scraper**](https://github.com/HeyClioo/boss-zhipin-jd-scraper) | ![GitHub Repo stars](https://badgen.net/github/stars/HeyClioo/boss-zhipin-jd-scraper) | 用真实已登录浏览器抓取 BOSS直聘岗位职责/任职要求全文，绕过反爬验证、去水印、按职位 ID 去重，导出 Markdown（Claude Code / Codex / WorkBuddy 适配）。 |
 
 ---
 


### PR DESCRIPTION
新增一个中文社区 Skill：**BOSS直聘 JD 抓取**。

- 仓库：https://github.com/HeyClioo/boss-zhipin-jd-scraper
- 用真实已登录浏览器（不是无头）抓取 BOSS直聘岗位职责/任职要求全文：绕过反爬安全验证、去 `display:none` 水印诱饵词、按 `encryptJobId` 去重，导出 Markdown。
- 适配 Claude Code / Codex / WorkBuddy，含中英双语 README 与 SKILL.md。
- 已加到「🇨🇳 中文社区 Skills」表尾，格式与现有条目一致，链接可访问（200）。

**为什么值得收录**：面向中文求职 / 招聘调研的垂直场景 Skill，解决了 BOSS直聘反爬这个具体难题，文档完整、可复用。