### PR TITLE
Add nathanskill/niubiskill (商业化决策 Skill) to Chinese Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ GitHub 上 Star 数最高、最具话题度的单一用途 Skill。它们大多�
 | [**iamzifei/wechat-article-publisher-skill**](https://github.com/iamzifei/wechat-article-publisher-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/iamzifei/wechat-article-publisher-skill) | 一键发布文章到微信公众号的 Claude Skill。 |
 | [**GanymedeNil/poxiaoxing-skills**](https://github.com/GanymedeNil/poxiaoxing-skills) (破晓星) | ![GitHub Repo stars](https://badgen.net/github/stars/GanymedeNil/poxiaoxing-skills) | 知名开发者 [@GanymedeNil](https://github.com/GanymedeNil) 出品的破晓星 Skills 仓库，内含「抖音博主分析」技能：采集博主作品、下载视频、抽取截图，并可选用 DashScope FunASR 转写字幕，输出结构化素材供后续分析。 |
 | [**dososo/blcaptain-ppt-skill**](https://github.com/dososo/blcaptain-ppt-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/dososo/blcaptain-ppt-skill) | AI 原生·单文件 HTML 演示 Skill：7 套锚定公认设计体系的视觉人格，好看（WCAG/间距/32 维审计）与诚实（反伪造）均由机器强制，零依赖。 |
+| [**nathanskill/niubiskill**](https://github.com/nathanskill/niubiskill) | ![GitHub Repo stars](https://badgen.net/github/stars/nathanskill/niubiskill) | 商业化决策 Skill：打断无收入验证的瞎忙——找到离真实收钱最近的一步，二选一（引流 / 成交），停掉一件分散精力的事，并给出 7 天证据测试。 |
 
 ---
 


### PR DESCRIPTION
新增一个中文社区 Skill：**niubiskill（商业化决策）**。

- 仓库：https://github.com/nathanskill/niubiskill（Apache-2.0，含 tests/ 与 scripts/validate，skill 本体在 `skills/niubiskill/SKILL.md`）
- 作用：打断无收入验证的瞎忙——找到离真实收钱最近的一步，二选一（引流 / 成交），停掉一件分散精力的事，并给出 7 天证据测试。
- 安装：`npx -y skills add nathanskill/niubiskill -g --all`（兼容 `npx skills add nathanskill/niubiskill`）
- 已加到「🇨🇳 中文社区 Skills」表尾，格式与现有条目一致，链接可访问（200），无重复条目。

**为什么值得收录**：中文为主的单一用途决策类 Skill，聚焦「项目怎么收钱」这一具体场景，输出结构化且可执行（单一收钱步骤 + 7 天证据测试），仓库带测试与校验脚本、维护活跃。

🤖 Generated with [Claude Code](https://claude.com/claude-code)