### PR TITLE
添加 house-skills-kit：中文房产 AI 技能生成骨架（29 模块 × 4 角色）

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ GitHub 上 Star 数最高、最具话题度的单一用途 Skill。它们大多�
 | [**iamzifei/wechat-article-publisher-skill**](https://github.com/iamzifei/wechat-article-publisher-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/iamzifei/wechat-article-publisher-skill) | 一键发布文章到微信公众号的 Claude Skill。 |
 | [**GanymedeNil/poxiaoxing-skills**](https://github.com/GanymedeNil/poxiaoxing-skills) (破晓星) | ![GitHub Repo stars](https://badgen.net/github/stars/GanymedeNil/poxiaoxing-skills) | 知名开发者 [@GanymedeNil](https://github.com/GanymedeNil) 出品的破晓星 Skills 仓库，内含「抖音博主分析」技能：采集博主作品、下载视频、抽取截图，并可选用 DashScope FunASR 转写字幕，输出结构化素材供后续分析。 |
 | [**dososo/blcaptain-ppt-skill**](https://github.com/dososo/blcaptain-ppt-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/dososo/blcaptain-ppt-skill) | AI 原生·单文件 HTML 演示 Skill：7 套锚定公认设计体系的视觉人格，好看（WCAG/间距/32 维审计）与诚实（反伪造）均由机器强制，零依赖。 |
+| [**danfeistar/house-skills-kit**](https://github.com/danfeistar/house-skills-kit) (房产技能包) | ![GitHub Repo stars](https://badgen.net/github/stars/danfeistar/house-skills-kit) | 中文房产 AI 技能生成骨架：29 个一线业务模块（判客 / 佣金政策 / 案场话术 / 验房清单 / 租赁红线），覆盖买房者、案场、经纪、渠道 4 类角色，一份 brand.yaml 生成品牌专属顾问 Skill，数据层适配器解耦。 |
 
 ---
 


### PR DESCRIPTION
## 新增条目

在「🇨🇳 中文社区 Skills」表格末尾添加：

**[danfeistar/house-skills-kit](https://github.com/danfeistar/house-skills-kit)**（房产技能包）

> 中文房产 AI 技能生成骨架：29 个一线业务模块（判客 / 佣金政策 / 案场话术 / 验房清单 / 租赁红线），覆盖买房者、案场、经纪、渠道 4 类角色，一份 brand.yaml 生成品牌专属顾问 Skill，数据层适配器解耦。

## 收录理由

- **填补垂类空白**：中文房产行业首个开源技能骨架，同类多为英文/通用型
- **真实业务沉淀**：模块来自 15 年一线地产营销实践（判客、佣金、验房等企业规范化场景），非工程师臆造 prompt
- **工程化设计**：模板+配置渲染架构、数据适配器解耦、Apache-2.0
- 条目格式按现有表格规范填写（含 stars 徽章）