### PR TITLE
收录 digital-employee-pack：面向非程序员的中文办公提效技能包

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ GitHub 上 Star 数最高、最具话题度的单一用途 Skill。它们大多�
 | [**GanymedeNil/poxiaoxing-skills**](https://github.com/GanymedeNil/poxiaoxing-skills) (破晓星) | ![GitHub Repo stars](https://badgen.net/github/stars/GanymedeNil/poxiaoxing-skills) | 知名开发者 [@GanymedeNil](https://github.com/GanymedeNil) 出品的破晓星 Skills 仓库，内含「抖音博主分析」技能：采集博主作品、下载视频、抽取截图，并可选用 DashScope FunASR 转写字幕，输出结构化素材供后续分析。 |
 | [**dososo/blcaptain-ppt-skill**](https://github.com/dososo/blcaptain-ppt-skill) | ![GitHub Repo stars](https://badgen.net/github/stars/dososo/blcaptain-ppt-skill) | AI 原生·单文件 HTML 演示 Skill：7 套锚定公认设计体系的视觉人格，好看（WCAG/间距/32 维审计）与诚实（反伪造）均由机器强制，零依赖。 |
 | [**nathanskill/niubiskill**](https://github.com/nathanskill/niubiskill) | ![GitHub Repo stars](https://badgen.net/github/stars/nathanskill/niubiskill) | 商业化决策 Skill：打断无收入验证的瞎忙——找到离真实收钱最近的一步，二选一（引流 / 成交），停掉一件分散精力的事，并给出 7 天证据测试。 |
+| [**Hahaknight/digital-employee-pack**](https://github.com/Hahaknight/digital-employee-pack) (数字员工配置包) | ![GitHub Repo stars](https://badgen.net/github/stars/Hahaknight/digital-employee-pack) | 面向非程序员的中文办公提效技能包：周报 / 会议纪要 / 表格清洗 + 防误删 Hooks + 全中文 SOP，附真实输出示例，一条命令安装。 |
 
 ---
 


### PR DESCRIPTION
收录到「🇨🇳 中文社区 Skills」表格。

**[digital-employee-pack（数字员工配置包）](https://github.com/Hahaknight/digital-employee-pack)**

- **定位**：面向非程序员职场用户的中文办公提效技能包——把「写周报、整理会议纪要、清洗表格」等高频重复工作固化成一条触发语就能用的 skills
- **内容**：周报生成器 / 会议纪要 / 表格清洗 + 防误删 Hooks + 全中文使用 SOP
- **真实性**：仓库附 [EXAMPLES.md](https://github.com/Hahaknight/digital-employee-pack/blob/main/EXAMPLES.md) 真实输出示例（技能在作者一周 29 条真实 git 提交上运行的完整产出，非演示虚构数据）
- **安装**：`npx skills add Hahaknight/digital-employee-pack`（也支持 Claude Code / Codex / Gemini CLI 等 75+ agents）
- 全中文文档，零编程门槛——正好补齐本列表「中文社区」区里非程序员受众的空缺

已在「开源 Skills 库」区提交过姊妹包 claude-skills-pro（PR #18），两包受众不同（工程师 vs 非程序员），非重复提交。