### PR TITLE
feat: 收录 hermes-md-preview（Hermes 桌面端 Markdown 预览插件）

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ GitHub 上 Star 数最高、最具话题度的单一用途 Skill。它们大多�
 | [**moatazhamada/ai-omni-skills**](https://github.com/moatazhamada/ai-omni-skills) | 跨工具同步 | ![GitHub Repo stars](https://badgen.net/github/stars/moatazhamada/ai-omni-skills) | 以单一 `SKILL.md` 为事实源 + 跨工具同步工具包（MCP server、共享指令、一键打通 Claude Code/Codex/Gemini/Kimi/Cursor/Kilocode/OpenCode），解决在多工具间技能碎片化的问题。 |
 | [**GBSOSS/mcp-to-skill-converter**](https://github.com/GBSOSS/-mcp-to-skill-converter) | MCP 转换 | ![GitHub Repo stars](https://badgen.net/github/stars/GBSOSS/-mcp-to-skill-converter) | 把任意 MCP server 转换成 Claude Skill，节省约 90% 上下文。 |
 | [**huifer/skill-security-scan**](https://github.com/huifer/skill-security-scan) | 安全扫描 | ![GitHub Repo stars](https://badgen.net/github/stars/huifer/skill-security-scan) | 安装第三方 Skill 前先做安全审查的命令行工具，检测窃取数据或破坏系统的恶意代码。 |
-| [**Xquik-dev/x-twitter-scraper**](https://github.com/Xquik-dev/x-twitter-scraper) | 数据抓取 | ![GitHub Repo stars](https://badgen.net/github/stars/Xquik-dev/x-twitter-scraper) | X/Twitter 数据抓取技能，提供 MCP 服务器与 REST API，含 20 个提取工具。 |
+| [**Xquik-dev/x-twitter-s
+| [**wlkerwong-boop/hermes-md-preview**](https://github.com/wlkerwong-boop/hermes-md-preview) | 桌面插件 | ![GitHub Repo stars](https://badgen.net/github/stars/wlkerwong-boop/hermes-md-preview) | Hermes 桌面端 Markdown 预览插件：跨会话扫描 agent 生成过的所有 .md 并在右侧窗格即时渲染，支持收藏与路径补全，中英双语。 |
+craper**](https://github.com/Xquik-dev/x-twitter-scraper) | 数据抓取 | ![GitHub Repo stars](https://badgen.net/github/stars/Xquik-dev/x-twitter-scraper) | X/Twitter 数据抓取技能，提供 MCP 服务器与 REST API，含 20 个提取工具。 |
 
 ---
 


### PR DESCRIPTION
## 收录内容

**[hermes-md-preview](https://github.com/wlkerwong-boop/hermes-md-preview)** — Hermes 桌面端 Markdown 预览插件。

### 功能
- 右侧窗格即时渲染 agent 生成的 .md（自研轻量 markdown 渲染器，中英双语）
- 跨会话扫描：汇总所有 profile 最近 30 个会话中 agent 写过的全部 .md
- 收藏夹、增量扫描缓存、路径模糊补全
- MIT 开源，v1.1.0

### 缘起
一位父亲用 Hermes Agent 为三个女儿搭建生命教育学习平台，AI 每天生成大量 Markdown 档案（课程、实验记录、研究报告）但桌面端无法预览——这个插件让它们一键可读。愿对中文 Hermes 用户有帮助。

### 收录位置
「🛠️ 工具与基础设施 (Tools & Infrastructure)」表格末尾，格式与现有条目一致。

- [x] 已按 CONTRIBUTING.md 规范填写表格
- [x] 项目为 MIT 开源
- [x] 非营销软文，真实在用的工具